### PR TITLE
feat: support Vite Supabase env variables

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,17 @@
 import { createClient } from '@supabase/supabase-js';
 
 // These will be replaced with your actual Supabase project details
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || '';
+// Support both Vercel and Vite-style environment variable names
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  '';
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
 // Client for browser/public operations


### PR DESCRIPTION
## Summary
- allow Supabase client to use `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` when configuring Supabase

## Testing
- `npm test` *(fails: Failed to connect to localhost port 3000)*
- `npm run build` *(fails: Cannot find package '@hono/vite-cloudflare-pages')*

------
https://chatgpt.com/codex/tasks/task_e_68a6fe644754832b8f2e6ca5d564dacb