### PR TITLE
chore: prepare vercel build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 build/
 .wrangler/
 .mf/
+.vercel/
 
 # Environment variables
 .env
@@ -57,3 +58,4 @@ coverage/
 tmp/
 temp/
 *.tmp
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:vercel": "vercel dev",
     "dev:sandbox": "wrangler pages dev dist --d1=skooli-production --local --ip 0.0.0.0 --port 3000",
     "build": "vite build",
-    "build:vercel": "tsc -p tsconfig.api.json",
+    "build:vercel": "tsc -p tsconfig.api.json && node scripts/build-vercel.mjs",
     "preview": "wrangler pages dev dist",
     "deploy": "npm run build && wrangler pages deploy dist --project-name skooli",
     "deploy:vercel": "vercel --prod",

--- a/scripts/build-vercel.mjs
+++ b/scripts/build-vercel.mjs
@@ -1,0 +1,31 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const outDir = path.resolve('.vercel/output');
+const functionsDir = path.join(outDir, 'functions');
+const apiDir = path.join(functionsDir, 'api');
+const apiFile = path.join(apiDir, 'index.js');
+const apiFuncDir = path.join(apiDir, 'index.func');
+const routesDir = path.join(apiDir, 'routes');
+const libSrcDir = path.join(functionsDir, 'lib');
+const libDestDir = path.join(apiFuncDir, 'lib');
+
+await fs.mkdir(apiFuncDir, { recursive: true });
+await fs.rename(apiFile, path.join(apiFuncDir, 'index.js'));
+await fs.rename(routesDir, path.join(apiFuncDir, 'routes'));
+await fs.rename(libSrcDir, libDestDir);
+
+const indexPath = path.join(apiFuncDir, 'index.js');
+let indexContent = await fs.readFile(indexPath, 'utf8');
+indexContent = indexContent.replace(/\.\.\/lib\//g, './lib/');
+await fs.writeFile(indexPath, indexContent);
+
+const vcConfig = {
+  runtime: 'nodejs20.x',
+  handler: 'index.js'
+};
+await fs.writeFile(path.join(apiFuncDir, '.vc-config.json'), JSON.stringify(vcConfig, null, 2));
+
+const rootConfig = { version: 3 };
+await fs.writeFile(path.join(outDir, 'config.json'), JSON.stringify(rootConfig, null, 2));
+

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": ".vercel/output/functions",
     "lib": ["ESNext", "DOM"]
   },
   "include": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "npm run build:vercel",
-  "outputDirectory": "dist",
   "framework": null,
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- remove `outputDirectory` from `vercel.json`
- emit serverless functions to `.vercel/output/functions`
- ignore build artifacts

## Testing
- `npm run build:vercel`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe6b6aa0832bb944e1b763a04638