### PR TITLE
fix: ensure API uses .js extensions for ESM

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -4,11 +4,12 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 
 // Import Supabase-adapted routes
-import authRoutes from './routes/auth';
-import productRoutes from './routes/products';
-import cartRoutes from './routes/cart';
-import orderRoutes from './routes/orders';
-import paymentRoutes from './routes/payments';
+// The .js extension is required for Node's ES module resolver in production
+import authRoutes from './routes/auth.js';
+import productRoutes from './routes/products.js';
+import cartRoutes from './routes/cart.js';
+import orderRoutes from './routes/orders.js';
+import paymentRoutes from './routes/payments.js';
 
 const app = new Hono();
 

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { supabase } from '../../lib/supabase';
+// Import the Supabase client. The .js extension is necessary for Node's ESM loader
+import { supabase } from '../../lib/supabase.js';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 

--- a/api/routes/cart.ts
+++ b/api/routes/cart.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { supabase } from '../../lib/supabase';
+// Import Supabase client. Include .js for Node ESM resolution
+import { supabase } from '../../lib/supabase.js';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 

--- a/api/routes/orders.ts
+++ b/api/routes/orders.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { supabase } from '../../lib/supabase';
+// Import Supabase client for order operations (requires .js extension for ESM)
+import { supabase } from '../../lib/supabase.js';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 

--- a/api/routes/payments.ts
+++ b/api/routes/payments.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { supabase } from '../../lib/supabase';
+// Import Supabase client for payment operations. Include .js extension for Node ESM
+import { supabase } from '../../lib/supabase.js';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 

--- a/api/routes/products.ts
+++ b/api/routes/products.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { supabase } from '../../lib/supabase';
+// Import Supabase client for product queries. Node's ESM requires the .js extension
+import { supabase } from '../../lib/supabase.js';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions when importing API routes so Node's ESM resolver can load them
- update route files to import Supabase client with `.js` extension for production

## Testing
- `npm run build:vercel`
- `npm test` *(fails: Couldn't connect to server)*
- `npm run test:api` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a7074a2728832b8b13264cd0f6e53a