### PR TITLE
fix: allow tests without Supabase

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,17 +2,25 @@ import { createClient } from '@supabase/supabase-js';
 
 // These will be replaced with your actual Supabase project details
 // Support both Vercel and Vite-style environment variable names
+// Allow the application to start even when Supabase environment variables
+// are not provided. This is useful for local development or CI environments
+// where a real Supabase instance isn't available. In those cases we fall back
+// to harmless placeholder values which keep the client from throwing an error
+// at initialization time. Any actual Supabase calls will still fail at runtime
+// (which is fine for tests that don't exercise those paths).
 const supabaseUrl =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
   process.env.SUPABASE_URL ||
   process.env.VITE_SUPABASE_URL ||
-  '';
+  'http://localhost';
 const supabaseAnonKey =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
   process.env.SUPABASE_ANON_KEY ||
   process.env.VITE_SUPABASE_ANON_KEY ||
-  '';
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  'anon-key';
+const supabaseServiceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  'service-role-key';
 
 // Client for browser/public operations
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {

--- a/scripts/test-api.js
+++ b/scripts/test-api.js
@@ -7,7 +7,7 @@
 
 const baseUrl = process.env.API_URL || 'http://localhost:3000';
 
-async function testEndpoint(method, path, body = null) {
+export async function testEndpoint(method, path, body = null) {
   const url = `${baseUrl}${path}`;
   const options = {
     method,
@@ -21,7 +21,10 @@ async function testEndpoint(method, path, body = null) {
   }
   
   try {
-    const response = await fetch(url);
+    // Pass the configured options so that the correct HTTP method and body
+    // are used during the request. Previously this function always performed
+    // a GET request regardless of the supplied method.
+    const response = await fetch(url, options);
     const data = await response.json();
     
     console.log(`✅ ${method} ${path}`);
@@ -39,7 +42,7 @@ async function testEndpoint(method, path, body = null) {
   }
 }
 
-async function runTests() {
+export async function runTests() {
   console.log('🧪 Testing Skooli API Endpoints');
   console.log('================================\n');
   
@@ -64,9 +67,7 @@ async function runTests() {
   console.log('✨ API tests completed!');
 }
 
-// Run tests if this file is executed directly
-if (require.main === module) {
+// Run tests if this file is executed directly (ESM equivalent of require.main)
+if (import.meta.url === new URL(process.argv[1], 'file:').href) {
   runTests().catch(console.error);
 }
-
-module.exports = { testEndpoint, runTests };


### PR DESCRIPTION
## Summary
- fallback to placeholder Supabase configuration when env vars missing
- fix API test script to use HTTP options and run as ESM module

## Testing
- `npm test`
- `node scripts/test-api.js` *(fails: fetch failed – server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f7f30988832baccbba55296e3665