### PR TITLE
feat: add signup and login flows

### DIFF
--- a/scripts/test-api.js
+++ b/scripts/test-api.js
@@ -61,7 +61,13 @@ export async function runTests() {
   await testEndpoint('POST', '/api/auth/signup', {
     email: 'test@example.com',
     password: 'testpass123',
-    name: 'Test User'
+    first_name: 'Test',
+    last_name: 'User'
+  });
+
+  await testEndpoint('POST', '/api/auth/signin', {
+    email: 'test@example.com',
+    password: 'testpass123'
   });
   
   console.log('✨ API tests completed!');

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,48 +1,107 @@
 import { Hono } from 'hono';
 import { Bindings } from '../types';
-import { signUp, signIn, signOut, getCurrentUser } from '../../lib/supabase';
+import { signUp, signIn, signOut } from '../../lib/supabase';
 import { supabase } from '../../lib/supabase';
+import { z } from 'zod';
+import { zValidator } from '@hono/zod-validator';
 
 const authRoutes = new Hono<{ Bindings: Bindings }>();
 
-// User Registration
-authRoutes.post('/signup', async (c) => {
-  try {
-    const { email, password, ...metadata } = await c.req.json();
+// Validation schemas
+const signUpSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  phone: z.string().optional(),
+  school_id: z.string().uuid().optional(),
+  user_type: z.enum(['parent', 'student', 'school_admin', 'admin']).default('parent'),
+});
 
-    if (!email || !password) {
-      return c.json({ error: 'Email and password are required' }, 400);
-    }
+const signInSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+// User Registration
+authRoutes.post('/signup', zValidator('json', signUpSchema), async (c) => {
+  try {
+    const data = c.req.valid('json');
+    const { email, password, ...rest } = data;
 
     const origin = new URL(c.req.url).origin;
-    const { data, error } = await signUp(email, password, metadata, origin);
+    const { data: authData, error } = await signUp(email, password, rest, origin);
 
     if (error) {
       return c.json({ error: error.message }, 400);
     }
 
-    return c.json(data, 201);
+    if (!authData.user) {
+      return c.json({ error: 'Failed to create user' }, 500);
+    }
+
+    const { error: profileError } = await supabase
+      .from('user_profiles')
+      .insert({
+        id: authData.user.id,
+        email,
+        first_name: rest.first_name,
+        last_name: rest.last_name,
+        phone: rest.phone,
+        school_id: rest.school_id,
+        user_type: rest.user_type,
+      });
+
+    if (profileError) {
+      console.error('Profile creation error:', profileError);
+    }
+
+    return c.json({
+      message: 'Account created successfully. Please check your email to verify your account.',
+      user: {
+        id: authData.user.id,
+        email: authData.user.email,
+        emailVerified: authData.user.email_confirmed_at !== null,
+      },
+    }, 201);
   } catch (error: any) {
     return c.json({ error: error.message }, 500);
   }
 });
 
 // User Login
-authRoutes.post('/signin', async (c) => {
+authRoutes.post('/signin', zValidator('json', signInSchema), async (c) => {
   try {
-    const { email, password } = await c.req.json();
-
-    if (!email || !password) {
-      return c.json({ error: 'Email and password are required' }, 400);
-    }
-
+    const { email, password } = c.req.valid('json');
     const { data, error } = await signIn(email, password);
 
     if (error) {
-      return c.json({ error: error.message }, 401);
+      return c.json({ error: 'Invalid credentials' }, 401);
     }
 
-    return c.json(data);
+    if (!data.session || !data.user) {
+      return c.json({ error: 'Failed to create session' }, 500);
+    }
+
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('*')
+      .eq('id', data.user.id)
+      .single();
+
+    return c.json({
+      user: {
+        id: data.user.id,
+        email: data.user.email,
+        emailVerified: data.user.email_confirmed_at !== null,
+        profile,
+      },
+      session: {
+        access_token: data.session.access_token,
+        refresh_token: data.session.refresh_token,
+        expires_at: data.session.expires_at,
+      },
+    });
   } catch (error: any) {
     return c.json({ error: error.message }, 500);
   }


### PR DESCRIPTION
## Summary
- add zod validation and user profile creation to signup route
- return session tokens and profile data on signin
- extend API test script to cover signin

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:5173)*
- `node scripts/test-api.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a92afb5ed4832ba540731e494a227d